### PR TITLE
increased key malloc to allow for longer keys

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -180,7 +180,7 @@ void parseOpts( int argc, char** argv )
 	int c;
 	int option_index = 0;
 	FILE* fd;
-	char* key = malloc( sizeof(char)*20 );
+	char* key = malloc( sizeof(char)*128 );
 	char* pin = NULL;
 	exename = argv[0];
 


### PR DESCRIPTION
When sending a sigint I was getting these errors:

`*** Error in '/home/rudism/source/googauth/bin/googauth': free(): invalid next size (fast): 0x0000000000603010 ***`

with this stack trace:

```
#1  0x00007ffff7a6d93a in abort () from /usr/lib/libc.so.6
#2  0x00007ffff7aaabb2 in __libc_message () from /usr/lib/libc.so.6
#3  0x00007ffff7ab00fe in malloc_printerr () from /usr/lib/libc.so.6
#4  0x00007ffff7ab08db in _int_free () from /usr/lib/libc.so.6
#5  0x00000000004010de in parseOpts (argc=3, argv=0x7fffffffe9e8) at src/main.c:250
#6  0x0000000000401135 in main (argc=3, argv=0x7fffffffe9e8) at src/main.c:262
```

I think because the keys I was given are more than 20 characters (my key for Google is 33 bytes, and my key for AWS is 65 bytes). Increasing the `malloc` for `key` to 128 bytes instead of 20 fixed the issue.
